### PR TITLE
Update YouTube video link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### rxcpp example of live twitter analysis
 
-[![president-elect](https://img.youtube.com/vi/QFcy-jQpvBg/0.jpg)](https://www.youtube.com/edit?video_id=QFcy-jQpvBg)
+[![president-elect](https://img.youtube.com/vi/QFcy-jQpvBg/0.jpg)](https://www.youtube.com/watch?v=QFcy-jQpvBg)
 
 This project was inspired by a [talk](https://blog.niallconnaughton.com/2016/10/25/ndc-sydney-talk/) by @nconnaughton - [github](https://github.com/NiallConnaughton/rx-realtime-twitter), [twitter](https://twitter.com/nconnaughton) 
 


### PR DESCRIPTION
The video link in the README points to the edit page, which is only accessible by the creator of the movie. I've updated it to the "watch" page of the movie.